### PR TITLE
Remove unused text properties from barProps.

### DIFF
--- a/app/components/kitchen/Bars.jsx
+++ b/app/components/kitchen/Bars.jsx
@@ -47,14 +47,14 @@ export default StaticView({
       { icon: star }
     ],
     'icon-text': [
-      { icon: mailbox, text: 'Mailbox' },
-      { icon: stopwatch, text: 'Stopwatch' },
-      { icon: star, text: 'Star' }
+      { icon: mailbox },
+      { icon: stopwatch },
+      { icon: star }
     ],
     'icon-text-right': [
-      { icon: mailbox, text: 'Mailbox' },
-      { icon: stopwatch, text: 'Stopwatch' },
-      { icon: star, text: 'Star' }
+      { icon: mailbox },
+      { icon: stopwatch },
+      { icon: star }
     ]
   },
 


### PR DESCRIPTION
...with a view to collapsing barProps into a single shared barProps object. Does it need to be different for the various barTypes?
